### PR TITLE
Add enum description to repeated enums and wrapped enums

### DIFF
--- a/internal/gen/messages_set.go
+++ b/internal/gen/messages_set.go
@@ -111,6 +111,8 @@ nextField:
 			switch field.Desc.Kind() {
 			default:
 				g.P("flags.AddFlag(", flagspluginPackage.Ident("New"+g.libNameForField(field)+"SliceFlag"), "(", flagspluginPackage.Ident("Prefix"), `("`, flagName, `", prefix), "", `, flagspluginPackage.Ident("WithHidden"), ifThenElse(hidden, "(true)", "(hidden)"), "))")
+			case protoreflect.EnumKind:
+				g.P("flags.AddFlag(", flagspluginPackage.Ident("New"+g.libNameForField(field)+"SliceFlag"), "(", flagspluginPackage.Ident("Prefix"), `("`, flagName, `", prefix),`, flagspluginPackage.Ident("EnumValueDesc("), field.Enum.GoIdent, "_value), ", flagspluginPackage.Ident("WithHidden"), ifThenElse(hidden, "(true)", "(hidden)"), "))")
 			case protoreflect.MessageKind:
 				switch {
 				case messageIsWrapper(field.Message):

--- a/test/gogo/enums_flags.pb.go
+++ b/test/gogo/enums_flags.pb.go
@@ -100,9 +100,9 @@ func PathsFromSelectFlagsForMessageWithEnums(flags *pflag.FlagSet, prefix string
 // AddSetFlagsForMessageWithEnums adds flags to select fields in MessageWithEnums.
 func AddSetFlagsForMessageWithEnums(flags *pflag.FlagSet, prefix string, hidden bool) {
 	flags.AddFlag(flagsplugin.NewStringFlag(flagsplugin.Prefix("regular", prefix), flagsplugin.EnumValueDesc(RegularEnum_value), flagsplugin.WithHidden(hidden)))
-	flags.AddFlag(flagsplugin.NewStringSliceFlag(flagsplugin.Prefix("regulars", prefix), "", flagsplugin.WithHidden(hidden)))
+	flags.AddFlag(flagsplugin.NewStringSliceFlag(flagsplugin.Prefix("regulars", prefix), flagsplugin.EnumValueDesc(RegularEnum_value), flagsplugin.WithHidden(hidden)))
 	flags.AddFlag(flagsplugin.NewStringFlag(flagsplugin.Prefix("custom", prefix), flagsplugin.EnumValueDesc(CustomEnum_value), flagsplugin.WithHidden(hidden)))
-	flags.AddFlag(flagsplugin.NewStringSliceFlag(flagsplugin.Prefix("customs", prefix), "", flagsplugin.WithHidden(hidden)))
+	flags.AddFlag(flagsplugin.NewStringSliceFlag(flagsplugin.Prefix("customs", prefix), flagsplugin.EnumValueDesc(CustomEnum_value), flagsplugin.WithHidden(hidden)))
 	AddSetFlagsForCustomEnumValue(flags, flagsplugin.Prefix("wrapped-custom", prefix), hidden)
 	flagsplugin.AddAlias(flags, flagsplugin.Prefix("wrapped-custom.value", prefix), flagsplugin.Prefix("wrapped-custom", prefix), flagsplugin.WithHidden(hidden))
 	flags.AddFlag(flagsplugin.NewStringSliceFlag(flagsplugin.Prefix("wrapped-customs", prefix), flagsplugin.EnumValueDesc(CustomEnum_value), flagsplugin.WithHidden(hidden)))

--- a/test/golang/enums_flags.pb.go
+++ b/test/golang/enums_flags.pb.go
@@ -100,9 +100,9 @@ func PathsFromSelectFlagsForMessageWithEnums(flags *pflag.FlagSet, prefix string
 // AddSetFlagsForMessageWithEnums adds flags to select fields in MessageWithEnums.
 func AddSetFlagsForMessageWithEnums(flags *pflag.FlagSet, prefix string, hidden bool) {
 	flags.AddFlag(flagsplugin.NewStringFlag(flagsplugin.Prefix("regular", prefix), flagsplugin.EnumValueDesc(RegularEnum_value), flagsplugin.WithHidden(hidden)))
-	flags.AddFlag(flagsplugin.NewStringSliceFlag(flagsplugin.Prefix("regulars", prefix), "", flagsplugin.WithHidden(hidden)))
+	flags.AddFlag(flagsplugin.NewStringSliceFlag(flagsplugin.Prefix("regulars", prefix), flagsplugin.EnumValueDesc(RegularEnum_value), flagsplugin.WithHidden(hidden)))
 	flags.AddFlag(flagsplugin.NewStringFlag(flagsplugin.Prefix("custom", prefix), flagsplugin.EnumValueDesc(CustomEnum_value), flagsplugin.WithHidden(hidden)))
-	flags.AddFlag(flagsplugin.NewStringSliceFlag(flagsplugin.Prefix("customs", prefix), "", flagsplugin.WithHidden(hidden)))
+	flags.AddFlag(flagsplugin.NewStringSliceFlag(flagsplugin.Prefix("customs", prefix), flagsplugin.EnumValueDesc(CustomEnum_value), flagsplugin.WithHidden(hidden)))
 	AddSetFlagsForCustomEnumValue(flags, flagsplugin.Prefix("wrapped-custom", prefix), hidden)
 	flagsplugin.AddAlias(flags, flagsplugin.Prefix("wrapped-custom.value", prefix), flagsplugin.Prefix("wrapped-custom", prefix), flagsplugin.WithHidden(hidden))
 	flags.AddFlag(flagsplugin.NewStringSliceFlag(flagsplugin.Prefix("wrapped-customs", prefix), flagsplugin.EnumValueDesc(CustomEnum_value), flagsplugin.WithHidden(hidden)))


### PR DESCRIPTION
Previously only single enum field flags had description, with this PR all enum related fields have one.