### PR TITLE
Add `semantical` for message with `set` tag

### DIFF
--- a/test/gogo/message.pb.go
+++ b/test/gogo/message.pb.go
@@ -22,259 +22,309 @@ var _ = math.Inf
 // proto package needs to be updated.
 const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
-type NonSemantic struct {
-	Semantic             *NonSemantic_Semantic `protobuf:"bytes,1,opt,name=semantic,proto3" json:"semantic,omitempty"`
-	OverruledSemantic    *NonSemantic_Semantic `protobuf:"bytes,2,opt,name=overruled_semantic,json=overruledSemantic,proto3" json:"overruled_semantic,omitempty"`
-	XXX_NoUnkeyedLiteral struct{}              `json:"-"`
-	XXX_unrecognized     []byte                `json:"-"`
-	XXX_sizecache        int32                 `json:"-"`
+type SemanticalMessage struct {
+	Empty                *SemanticalMessage_Empty    `protobuf:"bytes,1,opt,name=empty,proto3" json:"empty,omitempty"`
+	EmptyOverruled       *SemanticalMessage_Empty    `protobuf:"bytes,2,opt,name=empty_overruled,json=emptyOverruled,proto3" json:"empty_overruled,omitempty"`
+	NonEmpty             *SemanticalMessage_NonEmpty `protobuf:"bytes,3,opt,name=non_empty,json=nonEmpty,proto3" json:"non_empty,omitempty"`
+	XXX_NoUnkeyedLiteral struct{}                    `json:"-"`
+	XXX_unrecognized     []byte                      `json:"-"`
+	XXX_sizecache        int32                       `json:"-"`
 }
 
-func (m *NonSemantic) Reset()         { *m = NonSemantic{} }
-func (m *NonSemantic) String() string { return proto.CompactTextString(m) }
-func (*NonSemantic) ProtoMessage()    {}
-func (*NonSemantic) Descriptor() ([]byte, []int) {
+func (m *SemanticalMessage) Reset()         { *m = SemanticalMessage{} }
+func (m *SemanticalMessage) String() string { return proto.CompactTextString(m) }
+func (*SemanticalMessage) ProtoMessage()    {}
+func (*SemanticalMessage) Descriptor() ([]byte, []int) {
 	return fileDescriptor_33c57e4bae7b9afd, []int{0}
 }
-func (m *NonSemantic) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_NonSemantic.Unmarshal(m, b)
+func (m *SemanticalMessage) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_SemanticalMessage.Unmarshal(m, b)
 }
-func (m *NonSemantic) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_NonSemantic.Marshal(b, m, deterministic)
+func (m *SemanticalMessage) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_SemanticalMessage.Marshal(b, m, deterministic)
 }
-func (m *NonSemantic) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_NonSemantic.Merge(m, src)
+func (m *SemanticalMessage) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SemanticalMessage.Merge(m, src)
 }
-func (m *NonSemantic) XXX_Size() int {
-	return xxx_messageInfo_NonSemantic.Size(m)
+func (m *SemanticalMessage) XXX_Size() int {
+	return xxx_messageInfo_SemanticalMessage.Size(m)
 }
-func (m *NonSemantic) XXX_DiscardUnknown() {
-	xxx_messageInfo_NonSemantic.DiscardUnknown(m)
+func (m *SemanticalMessage) XXX_DiscardUnknown() {
+	xxx_messageInfo_SemanticalMessage.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_NonSemantic proto.InternalMessageInfo
+var xxx_messageInfo_SemanticalMessage proto.InternalMessageInfo
 
-func (m *NonSemantic) GetSemantic() *NonSemantic_Semantic {
+func (m *SemanticalMessage) GetEmpty() *SemanticalMessage_Empty {
 	if m != nil {
-		return m.Semantic
+		return m.Empty
 	}
 	return nil
 }
 
-func (m *NonSemantic) GetOverruledSemantic() *NonSemantic_Semantic {
+func (m *SemanticalMessage) GetEmptyOverruled() *SemanticalMessage_Empty {
 	if m != nil {
-		return m.OverruledSemantic
+		return m.EmptyOverruled
 	}
 	return nil
 }
 
-type NonSemantic_Semantic struct {
+func (m *SemanticalMessage) GetNonEmpty() *SemanticalMessage_NonEmpty {
+	if m != nil {
+		return m.NonEmpty
+	}
+	return nil
+}
+
+type SemanticalMessage_Empty struct {
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
 }
 
-func (m *NonSemantic_Semantic) Reset()         { *m = NonSemantic_Semantic{} }
-func (m *NonSemantic_Semantic) String() string { return proto.CompactTextString(m) }
-func (*NonSemantic_Semantic) ProtoMessage()    {}
-func (*NonSemantic_Semantic) Descriptor() ([]byte, []int) {
+func (m *SemanticalMessage_Empty) Reset()         { *m = SemanticalMessage_Empty{} }
+func (m *SemanticalMessage_Empty) String() string { return proto.CompactTextString(m) }
+func (*SemanticalMessage_Empty) ProtoMessage()    {}
+func (*SemanticalMessage_Empty) Descriptor() ([]byte, []int) {
 	return fileDescriptor_33c57e4bae7b9afd, []int{0, 0}
 }
-func (m *NonSemantic_Semantic) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_NonSemantic_Semantic.Unmarshal(m, b)
+func (m *SemanticalMessage_Empty) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_SemanticalMessage_Empty.Unmarshal(m, b)
 }
-func (m *NonSemantic_Semantic) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_NonSemantic_Semantic.Marshal(b, m, deterministic)
+func (m *SemanticalMessage_Empty) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_SemanticalMessage_Empty.Marshal(b, m, deterministic)
 }
-func (m *NonSemantic_Semantic) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_NonSemantic_Semantic.Merge(m, src)
+func (m *SemanticalMessage_Empty) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SemanticalMessage_Empty.Merge(m, src)
 }
-func (m *NonSemantic_Semantic) XXX_Size() int {
-	return xxx_messageInfo_NonSemantic_Semantic.Size(m)
+func (m *SemanticalMessage_Empty) XXX_Size() int {
+	return xxx_messageInfo_SemanticalMessage_Empty.Size(m)
 }
-func (m *NonSemantic_Semantic) XXX_DiscardUnknown() {
-	xxx_messageInfo_NonSemantic_Semantic.DiscardUnknown(m)
+func (m *SemanticalMessage_Empty) XXX_DiscardUnknown() {
+	xxx_messageInfo_SemanticalMessage_Empty.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_NonSemantic_Semantic proto.InternalMessageInfo
+var xxx_messageInfo_SemanticalMessage_Empty proto.InternalMessageInfo
 
-type OneOf struct {
+type SemanticalMessage_NonEmpty struct {
+	BoolValue            bool     `protobuf:"varint,1,opt,name=bool_value,json=boolValue,proto3" json:"bool_value,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (m *SemanticalMessage_NonEmpty) Reset()         { *m = SemanticalMessage_NonEmpty{} }
+func (m *SemanticalMessage_NonEmpty) String() string { return proto.CompactTextString(m) }
+func (*SemanticalMessage_NonEmpty) ProtoMessage()    {}
+func (*SemanticalMessage_NonEmpty) Descriptor() ([]byte, []int) {
+	return fileDescriptor_33c57e4bae7b9afd, []int{0, 1}
+}
+func (m *SemanticalMessage_NonEmpty) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_SemanticalMessage_NonEmpty.Unmarshal(m, b)
+}
+func (m *SemanticalMessage_NonEmpty) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_SemanticalMessage_NonEmpty.Marshal(b, m, deterministic)
+}
+func (m *SemanticalMessage_NonEmpty) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SemanticalMessage_NonEmpty.Merge(m, src)
+}
+func (m *SemanticalMessage_NonEmpty) XXX_Size() int {
+	return xxx_messageInfo_SemanticalMessage_NonEmpty.Size(m)
+}
+func (m *SemanticalMessage_NonEmpty) XXX_DiscardUnknown() {
+	xxx_messageInfo_SemanticalMessage_NonEmpty.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_SemanticalMessage_NonEmpty proto.InternalMessageInfo
+
+func (m *SemanticalMessage_NonEmpty) GetBoolValue() bool {
+	if m != nil {
+		return m.BoolValue
+	}
+	return false
+}
+
+type SemanticalOneOfMessage struct {
 	// Types that are valid to be assigned to Option:
 	//
-	//	*OneOf_Semantic_
-	//	*OneOf_NonSemantic_
-	Option               isOneOf_Option `protobuf_oneof:"option"`
-	XXX_NoUnkeyedLiteral struct{}       `json:"-"`
-	XXX_unrecognized     []byte         `json:"-"`
-	XXX_sizecache        int32          `json:"-"`
+	//	*SemanticalOneOfMessage_Semantical
+	//	*SemanticalOneOfMessage_Alternative
+	Option               isSemanticalOneOfMessage_Option `protobuf_oneof:"option"`
+	XXX_NoUnkeyedLiteral struct{}                        `json:"-"`
+	XXX_unrecognized     []byte                          `json:"-"`
+	XXX_sizecache        int32                           `json:"-"`
 }
 
-func (m *OneOf) Reset()         { *m = OneOf{} }
-func (m *OneOf) String() string { return proto.CompactTextString(m) }
-func (*OneOf) ProtoMessage()    {}
-func (*OneOf) Descriptor() ([]byte, []int) {
+func (m *SemanticalOneOfMessage) Reset()         { *m = SemanticalOneOfMessage{} }
+func (m *SemanticalOneOfMessage) String() string { return proto.CompactTextString(m) }
+func (*SemanticalOneOfMessage) ProtoMessage()    {}
+func (*SemanticalOneOfMessage) Descriptor() ([]byte, []int) {
 	return fileDescriptor_33c57e4bae7b9afd, []int{1}
 }
-func (m *OneOf) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_OneOf.Unmarshal(m, b)
+func (m *SemanticalOneOfMessage) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_SemanticalOneOfMessage.Unmarshal(m, b)
 }
-func (m *OneOf) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_OneOf.Marshal(b, m, deterministic)
+func (m *SemanticalOneOfMessage) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_SemanticalOneOfMessage.Marshal(b, m, deterministic)
 }
-func (m *OneOf) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_OneOf.Merge(m, src)
+func (m *SemanticalOneOfMessage) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SemanticalOneOfMessage.Merge(m, src)
 }
-func (m *OneOf) XXX_Size() int {
-	return xxx_messageInfo_OneOf.Size(m)
+func (m *SemanticalOneOfMessage) XXX_Size() int {
+	return xxx_messageInfo_SemanticalOneOfMessage.Size(m)
 }
-func (m *OneOf) XXX_DiscardUnknown() {
-	xxx_messageInfo_OneOf.DiscardUnknown(m)
-}
-
-var xxx_messageInfo_OneOf proto.InternalMessageInfo
-
-type isOneOf_Option interface {
-	isOneOf_Option()
+func (m *SemanticalOneOfMessage) XXX_DiscardUnknown() {
+	xxx_messageInfo_SemanticalOneOfMessage.DiscardUnknown(m)
 }
 
-type OneOf_Semantic_ struct {
-	Semantic *OneOf_Semantic `protobuf:"bytes,1,opt,name=semantic,proto3,oneof" json:"semantic,omitempty"`
-}
-type OneOf_NonSemantic_ struct {
-	NonSemantic *OneOf_NonSemantic `protobuf:"bytes,2,opt,name=non_semantic,json=nonSemantic,proto3,oneof" json:"non_semantic,omitempty"`
+var xxx_messageInfo_SemanticalOneOfMessage proto.InternalMessageInfo
+
+type isSemanticalOneOfMessage_Option interface {
+	isSemanticalOneOfMessage_Option()
 }
 
-func (*OneOf_Semantic_) isOneOf_Option()    {}
-func (*OneOf_NonSemantic_) isOneOf_Option() {}
+type SemanticalOneOfMessage_Semantical struct {
+	Semantical *SemanticalOneOfMessage_Empty `protobuf:"bytes,1,opt,name=semantical,proto3,oneof" json:"semantical,omitempty"`
+}
+type SemanticalOneOfMessage_Alternative struct {
+	Alternative *SemanticalOneOfMessage_NonEmpty `protobuf:"bytes,2,opt,name=alternative,proto3,oneof" json:"alternative,omitempty"`
+}
 
-func (m *OneOf) GetOption() isOneOf_Option {
+func (*SemanticalOneOfMessage_Semantical) isSemanticalOneOfMessage_Option()  {}
+func (*SemanticalOneOfMessage_Alternative) isSemanticalOneOfMessage_Option() {}
+
+func (m *SemanticalOneOfMessage) GetOption() isSemanticalOneOfMessage_Option {
 	if m != nil {
 		return m.Option
 	}
 	return nil
 }
 
-func (m *OneOf) GetSemantic() *OneOf_Semantic {
-	if x, ok := m.GetOption().(*OneOf_Semantic_); ok {
-		return x.Semantic
+func (m *SemanticalOneOfMessage) GetSemantical() *SemanticalOneOfMessage_Empty {
+	if x, ok := m.GetOption().(*SemanticalOneOfMessage_Semantical); ok {
+		return x.Semantical
 	}
 	return nil
 }
 
-func (m *OneOf) GetNonSemantic() *OneOf_NonSemantic {
-	if x, ok := m.GetOption().(*OneOf_NonSemantic_); ok {
-		return x.NonSemantic
+func (m *SemanticalOneOfMessage) GetAlternative() *SemanticalOneOfMessage_NonEmpty {
+	if x, ok := m.GetOption().(*SemanticalOneOfMessage_Alternative); ok {
+		return x.Alternative
 	}
 	return nil
 }
 
 // XXX_OneofWrappers is for the internal use of the proto package.
-func (*OneOf) XXX_OneofWrappers() []interface{} {
+func (*SemanticalOneOfMessage) XXX_OneofWrappers() []interface{} {
 	return []interface{}{
-		(*OneOf_Semantic_)(nil),
-		(*OneOf_NonSemantic_)(nil),
+		(*SemanticalOneOfMessage_Semantical)(nil),
+		(*SemanticalOneOfMessage_Alternative)(nil),
 	}
 }
 
-type OneOf_Semantic struct {
+type SemanticalOneOfMessage_Empty struct {
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
 }
 
-func (m *OneOf_Semantic) Reset()         { *m = OneOf_Semantic{} }
-func (m *OneOf_Semantic) String() string { return proto.CompactTextString(m) }
-func (*OneOf_Semantic) ProtoMessage()    {}
-func (*OneOf_Semantic) Descriptor() ([]byte, []int) {
+func (m *SemanticalOneOfMessage_Empty) Reset()         { *m = SemanticalOneOfMessage_Empty{} }
+func (m *SemanticalOneOfMessage_Empty) String() string { return proto.CompactTextString(m) }
+func (*SemanticalOneOfMessage_Empty) ProtoMessage()    {}
+func (*SemanticalOneOfMessage_Empty) Descriptor() ([]byte, []int) {
 	return fileDescriptor_33c57e4bae7b9afd, []int{1, 0}
 }
-func (m *OneOf_Semantic) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_OneOf_Semantic.Unmarshal(m, b)
+func (m *SemanticalOneOfMessage_Empty) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_SemanticalOneOfMessage_Empty.Unmarshal(m, b)
 }
-func (m *OneOf_Semantic) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_OneOf_Semantic.Marshal(b, m, deterministic)
+func (m *SemanticalOneOfMessage_Empty) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_SemanticalOneOfMessage_Empty.Marshal(b, m, deterministic)
 }
-func (m *OneOf_Semantic) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_OneOf_Semantic.Merge(m, src)
+func (m *SemanticalOneOfMessage_Empty) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SemanticalOneOfMessage_Empty.Merge(m, src)
 }
-func (m *OneOf_Semantic) XXX_Size() int {
-	return xxx_messageInfo_OneOf_Semantic.Size(m)
+func (m *SemanticalOneOfMessage_Empty) XXX_Size() int {
+	return xxx_messageInfo_SemanticalOneOfMessage_Empty.Size(m)
 }
-func (m *OneOf_Semantic) XXX_DiscardUnknown() {
-	xxx_messageInfo_OneOf_Semantic.DiscardUnknown(m)
+func (m *SemanticalOneOfMessage_Empty) XXX_DiscardUnknown() {
+	xxx_messageInfo_SemanticalOneOfMessage_Empty.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_OneOf_Semantic proto.InternalMessageInfo
+var xxx_messageInfo_SemanticalOneOfMessage_Empty proto.InternalMessageInfo
 
-type OneOf_NonSemantic struct {
-	Boolean              bool     `protobuf:"varint,1,opt,name=boolean,proto3" json:"boolean,omitempty"`
+type SemanticalOneOfMessage_NonEmpty struct {
+	BoolValue            bool     `protobuf:"varint,1,opt,name=bool_value,json=boolValue,proto3" json:"bool_value,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
 }
 
-func (m *OneOf_NonSemantic) Reset()         { *m = OneOf_NonSemantic{} }
-func (m *OneOf_NonSemantic) String() string { return proto.CompactTextString(m) }
-func (*OneOf_NonSemantic) ProtoMessage()    {}
-func (*OneOf_NonSemantic) Descriptor() ([]byte, []int) {
+func (m *SemanticalOneOfMessage_NonEmpty) Reset()         { *m = SemanticalOneOfMessage_NonEmpty{} }
+func (m *SemanticalOneOfMessage_NonEmpty) String() string { return proto.CompactTextString(m) }
+func (*SemanticalOneOfMessage_NonEmpty) ProtoMessage()    {}
+func (*SemanticalOneOfMessage_NonEmpty) Descriptor() ([]byte, []int) {
 	return fileDescriptor_33c57e4bae7b9afd, []int{1, 1}
 }
-func (m *OneOf_NonSemantic) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_OneOf_NonSemantic.Unmarshal(m, b)
+func (m *SemanticalOneOfMessage_NonEmpty) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_SemanticalOneOfMessage_NonEmpty.Unmarshal(m, b)
 }
-func (m *OneOf_NonSemantic) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_OneOf_NonSemantic.Marshal(b, m, deterministic)
+func (m *SemanticalOneOfMessage_NonEmpty) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_SemanticalOneOfMessage_NonEmpty.Marshal(b, m, deterministic)
 }
-func (m *OneOf_NonSemantic) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_OneOf_NonSemantic.Merge(m, src)
+func (m *SemanticalOneOfMessage_NonEmpty) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SemanticalOneOfMessage_NonEmpty.Merge(m, src)
 }
-func (m *OneOf_NonSemantic) XXX_Size() int {
-	return xxx_messageInfo_OneOf_NonSemantic.Size(m)
+func (m *SemanticalOneOfMessage_NonEmpty) XXX_Size() int {
+	return xxx_messageInfo_SemanticalOneOfMessage_NonEmpty.Size(m)
 }
-func (m *OneOf_NonSemantic) XXX_DiscardUnknown() {
-	xxx_messageInfo_OneOf_NonSemantic.DiscardUnknown(m)
+func (m *SemanticalOneOfMessage_NonEmpty) XXX_DiscardUnknown() {
+	xxx_messageInfo_SemanticalOneOfMessage_NonEmpty.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_OneOf_NonSemantic proto.InternalMessageInfo
+var xxx_messageInfo_SemanticalOneOfMessage_NonEmpty proto.InternalMessageInfo
 
-func (m *OneOf_NonSemantic) GetBoolean() bool {
+func (m *SemanticalOneOfMessage_NonEmpty) GetBoolValue() bool {
 	if m != nil {
-		return m.Boolean
+		return m.BoolValue
 	}
 	return false
 }
 
 func init() {
-	proto.RegisterType((*NonSemantic)(nil), "thethings.flags.test.NonSemantic")
-	proto.RegisterType((*NonSemantic_Semantic)(nil), "thethings.flags.test.NonSemantic.Semantic")
-	proto.RegisterType((*OneOf)(nil), "thethings.flags.test.OneOf")
-	proto.RegisterType((*OneOf_Semantic)(nil), "thethings.flags.test.OneOf.Semantic")
-	proto.RegisterType((*OneOf_NonSemantic)(nil), "thethings.flags.test.OneOf.NonSemantic")
+	proto.RegisterType((*SemanticalMessage)(nil), "thethings.flags.test.SemanticalMessage")
+	proto.RegisterType((*SemanticalMessage_Empty)(nil), "thethings.flags.test.SemanticalMessage.Empty")
+	proto.RegisterType((*SemanticalMessage_NonEmpty)(nil), "thethings.flags.test.SemanticalMessage.NonEmpty")
+	proto.RegisterType((*SemanticalOneOfMessage)(nil), "thethings.flags.test.SemanticalOneOfMessage")
+	proto.RegisterType((*SemanticalOneOfMessage_Empty)(nil), "thethings.flags.test.SemanticalOneOfMessage.Empty")
+	proto.RegisterType((*SemanticalOneOfMessage_NonEmpty)(nil), "thethings.flags.test.SemanticalOneOfMessage.NonEmpty")
 }
 
 func init() { proto.RegisterFile("message.proto", fileDescriptor_33c57e4bae7b9afd) }
 
 var fileDescriptor_33c57e4bae7b9afd = []byte{
-	// 323 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x94, 0x51, 0xcf, 0x4a, 0xfb, 0x40,
-	0x10, 0x4e, 0xca, 0xef, 0x17, 0x97, 0xad, 0x82, 0x0d, 0x1e, 0xda, 0x80, 0x50, 0x8a, 0x50, 0x11,
-	0xba, 0x11, 0x3d, 0x88, 0x1e, 0x73, 0xaa, 0x20, 0x2d, 0xc4, 0x9e, 0xbc, 0xc8, 0x36, 0x9d, 0x6e,
-	0x02, 0xe9, 0x4c, 0xc9, 0x6e, 0x7d, 0xa8, 0x3e, 0x92, 0x67, 0x9f, 0xa0, 0x4f, 0x20, 0xdd, 0x9a,
-	0x18, 0xb5, 0x08, 0xde, 0xbe, 0xd9, 0x99, 0xfd, 0xfe, 0xf0, 0xf1, 0xa3, 0x05, 0x68, 0x2d, 0x15,
-	0x88, 0x65, 0x41, 0x86, 0xfc, 0x13, 0x93, 0x82, 0x49, 0x33, 0x54, 0x5a, 0xcc, 0x73, 0xa9, 0xb4,
-	0x30, 0xa0, 0x4d, 0xd0, 0x92, 0x88, 0x64, 0xa4, 0xc9, 0x08, 0xf5, 0xee, 0x30, 0x38, 0xcd, 0xd0,
-	0x40, 0x81, 0x32, 0x0f, 0x15, 0x29, 0xb2, 0x6f, 0x16, 0xed, 0xd6, 0xbd, 0x57, 0x97, 0x37, 0x47,
-	0x84, 0x8f, 0xb0, 0x90, 0x68, 0xb2, 0xc4, 0x1f, 0x71, 0xa6, 0x3f, 0x70, 0xdb, 0xed, 0xba, 0xe7,
-	0xcd, 0xab, 0x0b, 0xb1, 0x4f, 0x4a, 0xd4, 0x3e, 0x89, 0x12, 0x44, 0xde, 0x66, 0xdd, 0x69, 0x30,
-	0x27, 0xae, 0x38, 0xfc, 0x84, 0xfb, 0xf4, 0x02, 0x45, 0xb1, 0xca, 0x61, 0xf6, 0x5c, 0x31, 0x37,
-	0xfe, 0xcc, 0xcc, 0x36, 0xeb, 0xce, 0x3f, 0xe6, 0x5c, 0x3a, 0x71, 0xab, 0xe2, 0x2b, 0x97, 0x01,
-	0xe7, 0xac, 0xc4, 0x77, 0x7c, 0xb3, 0xee, 0x78, 0xcc, 0x39, 0x76, 0xbb, 0x6e, 0xef, 0xcd, 0xe5,
-	0xff, 0xc7, 0x08, 0xe3, 0xb9, 0x1f, 0xfd, 0x88, 0x75, 0xb6, 0x5f, 0xdc, 0x9e, 0x57, 0xb2, 0xc3,
-	0x7a, 0x94, 0x07, 0x7e, 0x88, 0x84, 0xdf, 0x43, 0xf4, 0x7f, 0xe3, 0xa9, 0x45, 0x19, 0x3a, 0x71,
-	0x13, 0x3f, 0xc7, 0xba, 0xe7, 0xa0, 0xff, 0xb5, 0x83, 0x36, 0x3f, 0x98, 0x12, 0xe5, 0x20, 0xd1,
-	0x7a, 0x65, 0x71, 0x39, 0xd6, 0xc3, 0x45, 0x8c, 0x7b, 0xb4, 0xdc, 0x36, 0x1d, 0xdd, 0x3e, 0xdd,
-	0xa8, 0xcc, 0xa4, 0xab, 0xa9, 0x48, 0x68, 0x11, 0x4e, 0x52, 0x98, 0x58, 0x3b, 0xf7, 0x38, 0x5b,
-	0x69, 0x53, 0x64, 0xa0, 0x43, 0xdb, 0x75, 0x32, 0x50, 0x80, 0x03, 0x45, 0x03, 0x6b, 0x33, 0xdc,
-	0xda, 0x9c, 0x7a, 0x76, 0x73, 0xfd, 0x1e, 0x00, 0x00, 0xff, 0xff, 0x20, 0xfe, 0x6a, 0xd3, 0x5e,
-	0x02, 0x00, 0x00,
+	// 382 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xa4, 0x92, 0xcf, 0x6a, 0xc2, 0x40,
+	0x10, 0xc6, 0x93, 0xb4, 0xa6, 0x71, 0xa5, 0x7f, 0x0c, 0xa5, 0x68, 0x40, 0x10, 0x4f, 0xbd, 0x24,
+	0x11, 0xa5, 0x94, 0x7a, 0xb4, 0x14, 0xec, 0xc1, 0x0a, 0xa9, 0x14, 0xda, 0x43, 0x65, 0xd5, 0x71,
+	0x13, 0x48, 0x76, 0x25, 0xbb, 0x11, 0xfa, 0x30, 0x7d, 0x01, 0x5f, 0xa9, 0x6f, 0xe1, 0x13, 0x94,
+	0x6c, 0x92, 0x2a, 0xb4, 0xd0, 0x7f, 0xb7, 0x8f, 0x99, 0x9d, 0xdf, 0x7c, 0xf9, 0x32, 0xe8, 0x30,
+	0x02, 0xce, 0x31, 0x01, 0x67, 0x19, 0x33, 0xc1, 0xcc, 0x53, 0xe1, 0x83, 0xf0, 0x03, 0x4a, 0xb8,
+	0xb3, 0x08, 0x31, 0xe1, 0x8e, 0x00, 0x2e, 0xac, 0x2a, 0xa6, 0x94, 0x09, 0x2c, 0x02, 0x46, 0x79,
+	0xf6, 0xd0, 0x6a, 0x04, 0x54, 0x40, 0x4c, 0x71, 0xe8, 0x12, 0x46, 0x98, 0xac, 0x49, 0x95, 0xb5,
+	0x5b, 0x6f, 0x1a, 0xaa, 0xde, 0x43, 0x84, 0xa9, 0x08, 0x66, 0x38, 0x1c, 0x66, 0x3b, 0xcc, 0x6b,
+	0x54, 0x82, 0x68, 0x29, 0x5e, 0x6a, 0x6a, 0x53, 0x3d, 0xaf, 0x74, 0x6c, 0xe7, 0xab, 0x6d, 0xce,
+	0xa7, 0x39, 0xe7, 0x26, 0x1d, 0xf2, 0xb2, 0x59, 0xf3, 0x19, 0x1d, 0x4b, 0x31, 0x61, 0x2b, 0x88,
+	0xe3, 0x24, 0x84, 0x79, 0x4d, 0xfb, 0x03, 0xae, 0xaf, 0x6f, 0xd6, 0x75, 0xad, 0xad, 0x78, 0x47,
+	0x92, 0x36, 0x2a, 0x60, 0xe6, 0x10, 0x95, 0x29, 0xa3, 0x93, 0xcc, 0xe8, 0x9e, 0x24, 0xb7, 0x7f,
+	0x4a, 0xbe, 0x63, 0x34, 0xf3, 0x6a, 0xd0, 0x5c, 0x59, 0x55, 0x54, 0x92, 0xa2, 0x67, 0x6c, 0xd6,
+	0xf5, 0x7d, 0x43, 0x39, 0x51, 0xad, 0x2e, 0x32, 0x8a, 0x87, 0x66, 0x03, 0xa1, 0x29, 0x63, 0xe1,
+	0x64, 0x85, 0xc3, 0x04, 0x64, 0x2e, 0x86, 0x57, 0x4e, 0x2b, 0x0f, 0x69, 0x61, 0x3b, 0xd4, 0x43,
+	0x9b, 0x75, 0x5d, 0x4f, 0x55, 0x53, 0x6d, 0xbd, 0x6a, 0xe8, 0x6c, 0xbb, 0x7c, 0x44, 0x61, 0xb4,
+	0x28, 0x22, 0x1e, 0x23, 0xc4, 0x3f, 0x3a, 0x79, 0xce, 0x9d, 0xef, 0xec, 0xef, 0x12, 0xb2, 0x74,
+	0x06, 0x8a, 0xb7, 0xc3, 0x31, 0x1f, 0x51, 0x05, 0x87, 0xf2, 0x7f, 0x8b, 0x60, 0x05, 0x79, 0xde,
+	0x17, 0xbf, 0xc2, 0x16, 0x5f, 0x3c, 0x50, 0xbc, 0x5d, 0x96, 0x75, 0x90, 0xe7, 0xf3, 0xef, 0x54,
+	0xfa, 0x06, 0xd2, 0xd9, 0x32, 0xbd, 0xd1, 0xfe, 0xd5, 0xd3, 0x25, 0x09, 0x84, 0x9f, 0x4c, 0x9d,
+	0x19, 0x8b, 0xdc, 0xb1, 0x0f, 0x63, 0xe9, 0xf2, 0x96, 0xce, 0x13, 0x2e, 0xe2, 0x00, 0xb8, 0x2b,
+	0xaf, 0x74, 0x66, 0x13, 0xa0, 0x36, 0x61, 0xb6, 0x74, 0xef, 0xa6, 0xee, 0xa7, 0xba, 0xec, 0x74,
+	0xdf, 0x03, 0x00, 0x00, 0xff, 0xff, 0x10, 0xb5, 0x90, 0x79, 0x18, 0x03, 0x00, 0x00,
 }

--- a/test/gogo/message_flags.pb.go
+++ b/test/gogo/message_flags.pb.go
@@ -11,44 +11,126 @@ import (
 	pflag "github.com/spf13/pflag"
 )
 
-// AddSetFlagsForNonSemantic adds flags to select fields in NonSemantic.
-func AddSetFlagsForNonSemantic(flags *pflag.FlagSet, prefix string, hidden bool) {
-	flags.AddFlag(flagsplugin.NewBoolFlag(flagsplugin.Prefix("semantic", prefix), "", flagsplugin.WithHidden(hidden)))
-	// FIXME: Skipping OverruledSemantic because it does not seem to implement AddSetFlags.
+// AddSetFlagsForSemanticalMessage_Empty adds flags to select fields in SemanticalMessage_Empty.
+func AddSetFlagsForSemanticalMessage_Empty(flags *pflag.FlagSet, prefix string, hidden bool) {
 }
 
-// SetFromFlags sets the NonSemantic message from flags.
-func (m *NonSemantic) SetFromFlags(flags *pflag.FlagSet, prefix string) (paths []string, err error) {
-	if _, changed, err := flagsplugin.GetBool(flags, flagsplugin.Prefix("semantic", prefix)); err != nil {
-		return nil, err
-	} else if changed {
-		m.Semantic = &NonSemantic_Semantic{}
-		paths = append(paths, flagsplugin.Prefix("semantic", prefix))
-	}
-	// FIXME: Skipping OverruledSemantic because it does not seem to implement AddSetFlags.
+// SetFromFlags sets the SemanticalMessage_Empty message from flags.
+func (m *SemanticalMessage_Empty) SetFromFlags(flags *pflag.FlagSet, prefix string) (paths []string, err error) {
 	return paths, nil
 }
 
-// AddSetFlagsForOneOf adds flags to select fields in OneOf.
-func AddSetFlagsForOneOf(flags *pflag.FlagSet, prefix string, hidden bool) {
-	flags.AddFlag(flagsplugin.NewBoolFlag(flagsplugin.Prefix("option.semantic", prefix), "", flagsplugin.WithHidden(hidden)))
-	flags.AddFlag(flagsplugin.NewBoolFlag(flagsplugin.Prefix("option.non-semantic", prefix), "", flagsplugin.WithHidden(hidden)))
+// AddSetFlagsForSemanticalMessage_NonEmpty adds flags to select fields in SemanticalMessage_NonEmpty.
+func AddSetFlagsForSemanticalMessage_NonEmpty(flags *pflag.FlagSet, prefix string, hidden bool) {
+	flags.AddFlag(flagsplugin.NewBoolFlag(flagsplugin.Prefix("bool-value", prefix), "", flagsplugin.WithHidden(hidden)))
 }
 
-// SetFromFlags sets the OneOf message from flags.
-func (m *OneOf) SetFromFlags(flags *pflag.FlagSet, prefix string) (paths []string, err error) {
-	if _, changed, err := flagsplugin.GetBool(flags, flagsplugin.Prefix("option.semantic", prefix)); err != nil {
+// SetFromFlags sets the SemanticalMessage_NonEmpty message from flags.
+func (m *SemanticalMessage_NonEmpty) SetFromFlags(flags *pflag.FlagSet, prefix string) (paths []string, err error) {
+	if val, changed, err := flagsplugin.GetBool(flags, flagsplugin.Prefix("bool_value", prefix)); err != nil {
 		return nil, err
 	} else if changed {
-		ov := &OneOf_Semantic_{}
-		paths = append(paths, flagsplugin.Prefix("option.semantic", prefix))
+		m.BoolValue = val
+		paths = append(paths, flagsplugin.Prefix("bool_value", prefix))
+	}
+	return paths, nil
+}
+
+// AddSetFlagsForSemanticalMessage adds flags to select fields in SemanticalMessage.
+func AddSetFlagsForSemanticalMessage(flags *pflag.FlagSet, prefix string, hidden bool) {
+	AddSetFlagsForSemanticalMessage_Empty(flags, flagsplugin.Prefix("empty", prefix), hidden)
+	flags.AddFlag(flagsplugin.NewBoolFlag(flagsplugin.Prefix("empty", prefix), "", flagsplugin.WithHidden(hidden)))
+	AddSetFlagsForSemanticalMessage_Empty(flags, flagsplugin.Prefix("empty-overruled", prefix), hidden)
+	AddSetFlagsForSemanticalMessage_NonEmpty(flags, flagsplugin.Prefix("non-empty", prefix), hidden)
+	flags.AddFlag(flagsplugin.NewBoolFlag(flagsplugin.Prefix("non-empty", prefix), "", flagsplugin.WithHidden(hidden)))
+}
+
+// SetFromFlags sets the SemanticalMessage message from flags.
+func (m *SemanticalMessage) SetFromFlags(flags *pflag.FlagSet, prefix string) (paths []string, err error) {
+	if changed := flagsplugin.IsAnyPrefixSet(flags, flagsplugin.Prefix("empty", prefix)); changed {
+		if m.Empty == nil {
+			m.Empty = &SemanticalMessage_Empty{}
+		}
+		if setPaths, err := m.Empty.SetFromFlags(flags, flagsplugin.Prefix("empty", prefix)); err != nil {
+			return nil, err
+		} else if len(setPaths) == 0 {
+			paths = append(paths, "empty")
+		} else {
+			paths = append(paths, setPaths...)
+		}
+	}
+	if changed := flagsplugin.IsAnyPrefixSet(flags, flagsplugin.Prefix("empty_overruled", prefix)); changed {
+		if m.EmptyOverruled == nil {
+			m.EmptyOverruled = &SemanticalMessage_Empty{}
+		}
+		if setPaths, err := m.EmptyOverruled.SetFromFlags(flags, flagsplugin.Prefix("empty_overruled", prefix)); err != nil {
+			return nil, err
+		} else {
+			paths = append(paths, setPaths...)
+		}
+	}
+	if changed := flagsplugin.IsAnyPrefixSet(flags, flagsplugin.Prefix("non_empty", prefix)); changed {
+		if m.NonEmpty == nil {
+			m.NonEmpty = &SemanticalMessage_NonEmpty{}
+		}
+		if setPaths, err := m.NonEmpty.SetFromFlags(flags, flagsplugin.Prefix("non_empty", prefix)); err != nil {
+			return nil, err
+		} else if len(setPaths) == 0 {
+			paths = append(paths, "non_empty")
+		} else {
+			paths = append(paths, setPaths...)
+		}
+	}
+	return paths, nil
+}
+
+// AddSetFlagsForSemanticalOneOfMessage_NonEmpty adds flags to select fields in SemanticalOneOfMessage_NonEmpty.
+func AddSetFlagsForSemanticalOneOfMessage_NonEmpty(flags *pflag.FlagSet, prefix string, hidden bool) {
+	flags.AddFlag(flagsplugin.NewBoolFlag(flagsplugin.Prefix("bool-value", prefix), "", flagsplugin.WithHidden(hidden)))
+}
+
+// SetFromFlags sets the SemanticalOneOfMessage_NonEmpty message from flags.
+func (m *SemanticalOneOfMessage_NonEmpty) SetFromFlags(flags *pflag.FlagSet, prefix string) (paths []string, err error) {
+	if val, changed, err := flagsplugin.GetBool(flags, flagsplugin.Prefix("bool_value", prefix)); err != nil {
+		return nil, err
+	} else if changed {
+		m.BoolValue = val
+		paths = append(paths, flagsplugin.Prefix("bool_value", prefix))
+	}
+	return paths, nil
+}
+
+// AddSetFlagsForSemanticalOneOfMessage adds flags to select fields in SemanticalOneOfMessage.
+func AddSetFlagsForSemanticalOneOfMessage(flags *pflag.FlagSet, prefix string, hidden bool) {
+	flags.AddFlag(flagsplugin.NewBoolFlag(flagsplugin.Prefix("option.semantical", prefix), "", flagsplugin.WithHidden(hidden)))
+	AddSetFlagsForSemanticalOneOfMessage_NonEmpty(flags, flagsplugin.Prefix("option.alternative", prefix), hidden)
+	flags.AddFlag(flagsplugin.NewBoolFlag(flagsplugin.Prefix("option.alternative", prefix), "", flagsplugin.WithHidden(hidden)))
+}
+
+// SetFromFlags sets the SemanticalOneOfMessage message from flags.
+func (m *SemanticalOneOfMessage) SetFromFlags(flags *pflag.FlagSet, prefix string) (paths []string, err error) {
+	if _, changed, err := flagsplugin.GetBool(flags, flagsplugin.Prefix("option.semantical", prefix)); err != nil {
+		return nil, err
+	} else if changed {
+		ov := &SemanticalOneOfMessage_Semantical{}
+		if ov.Semantical == nil {
+			ov.Semantical = &SemanticalOneOfMessage_Empty{}
+		}
+		paths = append(paths, flagsplugin.Prefix("option.semantical", prefix))
 		m.Option = ov
 	}
-	if _, changed, err := flagsplugin.GetBool(flags, flagsplugin.Prefix("option.non_semantic", prefix)); err != nil {
-		return nil, err
-	} else if changed {
-		ov := &OneOf_NonSemantic_{}
-		paths = append(paths, flagsplugin.Prefix("option.non_semantic", prefix))
+	if changed := flagsplugin.IsAnyPrefixSet(flags, flagsplugin.Prefix("option.alternative", prefix)); changed {
+		ov := &SemanticalOneOfMessage_Alternative{}
+		if ov.Alternative == nil {
+			ov.Alternative = &SemanticalOneOfMessage_NonEmpty{}
+		}
+		if setPaths, err := ov.Alternative.SetFromFlags(flags, flagsplugin.Prefix("option.alternative", prefix)); err != nil {
+			return nil, err
+		} else if len(setPaths) == 0 {
+			paths = append(paths, "option.alternative")
+		} else {
+			paths = append(paths, setPaths...)
+		}
 		m.Option = ov
 	}
 	return paths, nil

--- a/test/gogo/message_test.go
+++ b/test/gogo/message_test.go
@@ -10,56 +10,102 @@ import (
 var testMessagesWithSemanticalMeaning = []struct {
 	name            string
 	arguments       []string
-	expectedMessage NonSemantic
+	expectedMessage SemanticalMessage
 	expectedMask    []string
 }{
 	{
 		name:      "exists",
-		arguments: []string{"--semantic"},
-		expectedMessage: NonSemantic{
-			Semantic: &NonSemantic_Semantic{},
+		arguments: []string{"--empty"},
+		expectedMessage: SemanticalMessage{
+			Empty: &SemanticalMessage_Empty{},
 		},
-		expectedMask: []string{"semantic"},
+		expectedMask: []string{"empty"},
 	},
 	{
 		name:      "doesn't exist",
 		arguments: []string{},
-		expectedMessage: NonSemantic{
-			Semantic: nil,
+		expectedMessage: SemanticalMessage{
+			Empty:          nil,
+			EmptyOverruled: nil,
+			NonEmpty:       nil,
 		},
 		expectedMask: nil,
+	},
+	{
+		name:      "overruled semantical",
+		arguments: []string{"--empty_overruled"},
+		expectedMessage: SemanticalMessage{
+			Empty:          nil,
+			EmptyOverruled: nil,
+			NonEmpty:       nil,
+		},
+		expectedMask: nil,
+	},
+	{
+		name:      "non_empty semantical",
+		arguments: []string{"--non-empty"},
+		expectedMessage: SemanticalMessage{
+			NonEmpty: &SemanticalMessage_NonEmpty{},
+		},
+		expectedMask: []string{"non_empty"},
+	},
+	{
+		name:      "non_empty with value",
+		arguments: []string{"--non-empty.bool-value", "true"},
+		expectedMessage: SemanticalMessage{
+			NonEmpty: &SemanticalMessage_NonEmpty{
+				BoolValue: true,
+			},
+		},
+		expectedMask: []string{"non_empty.bool_value"},
 	},
 }
 
 var testMessagesWithOneOfSemanticalMeaning = []struct {
 	name            string
 	arguments       []string
-	expectedMessage OneOf
+	expectedMessage SemanticalOneOfMessage
 	expectedMask    []string
 }{
 	{
-		name:      "semantic exists",
-		arguments: []string{"--option.semantic"},
-		expectedMessage: OneOf{
-			Option: &OneOf_Semantic_{},
+		name:      "alternative exists",
+		arguments: []string{"--option.alternative"},
+		expectedMessage: SemanticalOneOfMessage{
+			Option: &SemanticalOneOfMessage_Alternative{
+				Alternative: &SemanticalOneOfMessage_NonEmpty{},
+			},
 		},
-		expectedMask: []string{"option.semantic"},
+		expectedMask: []string{"option.alternative"},
 	},
 	{
 		name:      "doesn't exist",
 		arguments: []string{},
-		expectedMessage: OneOf{
+		expectedMessage: SemanticalOneOfMessage{
 			Option: nil,
 		},
 		expectedMask: nil,
 	},
 	{
-		name:      "nonsemantic exists",
-		arguments: []string{"--option.non-semantic"},
-		expectedMessage: OneOf{
-			Option: &OneOf_NonSemantic_{},
+		name:      "semantical exists",
+		arguments: []string{"--option.semantical"},
+		expectedMessage: SemanticalOneOfMessage{
+			Option: &SemanticalOneOfMessage_Semantical{
+				Semantical: &SemanticalOneOfMessage_Empty{},
+			},
 		},
-		expectedMask: []string{"option.non_semantic"},
+		expectedMask: []string{"option.semantical"},
+	},
+	{
+		name:      "alternative exists with value",
+		arguments: []string{"--option.alternative.bool-value", "true"},
+		expectedMessage: SemanticalOneOfMessage{
+			Option: &SemanticalOneOfMessage_Alternative{
+				Alternative: &SemanticalOneOfMessage_NonEmpty{
+					BoolValue: true,
+				},
+			},
+		},
+		expectedMask: []string{"option.alternative.bool_value"},
 	},
 }
 
@@ -67,7 +113,7 @@ func TestSetFlagsMessageWithSemanticalMeaning(t *testing.T) {
 	for _, tt := range testMessagesWithSemanticalMeaning {
 		t.Run(tt.name, func(t *testing.T) {
 			fs := &pflag.FlagSet{}
-			AddSetFlagsForNonSemantic(fs, "", false)
+			AddSetFlagsForSemanticalMessage(fs, "", false)
 			expectMessageEqual(t, fs, tt.arguments, &tt.expectedMessage, tt.expectedMask)
 		})
 	}
@@ -77,7 +123,7 @@ func TestSetFlagsMessageWithOneOfSemanticalMeaning(t *testing.T) {
 	for _, tt := range testMessagesWithOneOfSemanticalMeaning {
 		t.Run(tt.name, func(t *testing.T) {
 			fs := &pflag.FlagSet{}
-			AddSetFlagsForOneOf(fs, "", false)
+			AddSetFlagsForSemanticalOneOfMessage(fs, "", false)
 			expectMessageEqual(t, fs, tt.arguments, &tt.expectedMessage, tt.expectedMask)
 		})
 	}

--- a/test/golang/message.pb.go
+++ b/test/golang/message.pb.go
@@ -25,17 +25,18 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
-type NonSemantic struct {
+type SemanticalMessage struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Semantic          *NonSemantic_Semantic `protobuf:"bytes,1,opt,name=semantic,proto3" json:"semantic,omitempty"`
-	OverruledSemantic *NonSemantic_Semantic `protobuf:"bytes,2,opt,name=overruled_semantic,json=overruledSemantic,proto3" json:"overruled_semantic,omitempty"`
+	Empty          *SemanticalMessage_Empty    `protobuf:"bytes,1,opt,name=empty,proto3" json:"empty,omitempty"`
+	EmptyOverruled *SemanticalMessage_Empty    `protobuf:"bytes,2,opt,name=empty_overruled,json=emptyOverruled,proto3" json:"empty_overruled,omitempty"`
+	NonEmpty       *SemanticalMessage_NonEmpty `protobuf:"bytes,3,opt,name=non_empty,json=nonEmpty,proto3" json:"non_empty,omitempty"`
 }
 
-func (x *NonSemantic) Reset() {
-	*x = NonSemantic{}
+func (x *SemanticalMessage) Reset() {
+	*x = SemanticalMessage{}
 	if protoimpl.UnsafeEnabled {
 		mi := &file_message_proto_msgTypes[0]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -43,13 +44,13 @@ func (x *NonSemantic) Reset() {
 	}
 }
 
-func (x *NonSemantic) String() string {
+func (x *SemanticalMessage) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*NonSemantic) ProtoMessage() {}
+func (*SemanticalMessage) ProtoMessage() {}
 
-func (x *NonSemantic) ProtoReflect() protoreflect.Message {
+func (x *SemanticalMessage) ProtoReflect() protoreflect.Message {
 	mi := &file_message_proto_msgTypes[0]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -61,39 +62,46 @@ func (x *NonSemantic) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use NonSemantic.ProtoReflect.Descriptor instead.
-func (*NonSemantic) Descriptor() ([]byte, []int) {
+// Deprecated: Use SemanticalMessage.ProtoReflect.Descriptor instead.
+func (*SemanticalMessage) Descriptor() ([]byte, []int) {
 	return file_message_proto_rawDescGZIP(), []int{0}
 }
 
-func (x *NonSemantic) GetSemantic() *NonSemantic_Semantic {
+func (x *SemanticalMessage) GetEmpty() *SemanticalMessage_Empty {
 	if x != nil {
-		return x.Semantic
+		return x.Empty
 	}
 	return nil
 }
 
-func (x *NonSemantic) GetOverruledSemantic() *NonSemantic_Semantic {
+func (x *SemanticalMessage) GetEmptyOverruled() *SemanticalMessage_Empty {
 	if x != nil {
-		return x.OverruledSemantic
+		return x.EmptyOverruled
 	}
 	return nil
 }
 
-type OneOf struct {
+func (x *SemanticalMessage) GetNonEmpty() *SemanticalMessage_NonEmpty {
+	if x != nil {
+		return x.NonEmpty
+	}
+	return nil
+}
+
+type SemanticalOneOfMessage struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
 	// Types that are assignable to Option:
 	//
-	//	*OneOf_Semantic_
-	//	*OneOf_NonSemantic_
-	Option isOneOf_Option `protobuf_oneof:"option"`
+	//	*SemanticalOneOfMessage_Semantical
+	//	*SemanticalOneOfMessage_Alternative
+	Option isSemanticalOneOfMessage_Option `protobuf_oneof:"option"`
 }
 
-func (x *OneOf) Reset() {
-	*x = OneOf{}
+func (x *SemanticalOneOfMessage) Reset() {
+	*x = SemanticalOneOfMessage{}
 	if protoimpl.UnsafeEnabled {
 		mi := &file_message_proto_msgTypes[1]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -101,13 +109,13 @@ func (x *OneOf) Reset() {
 	}
 }
 
-func (x *OneOf) String() string {
+func (x *SemanticalOneOfMessage) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*OneOf) ProtoMessage() {}
+func (*SemanticalOneOfMessage) ProtoMessage() {}
 
-func (x *OneOf) ProtoReflect() protoreflect.Message {
+func (x *SemanticalOneOfMessage) ProtoReflect() protoreflect.Message {
 	mi := &file_message_proto_msgTypes[1]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -119,56 +127,56 @@ func (x *OneOf) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use OneOf.ProtoReflect.Descriptor instead.
-func (*OneOf) Descriptor() ([]byte, []int) {
+// Deprecated: Use SemanticalOneOfMessage.ProtoReflect.Descriptor instead.
+func (*SemanticalOneOfMessage) Descriptor() ([]byte, []int) {
 	return file_message_proto_rawDescGZIP(), []int{1}
 }
 
-func (m *OneOf) GetOption() isOneOf_Option {
+func (m *SemanticalOneOfMessage) GetOption() isSemanticalOneOfMessage_Option {
 	if m != nil {
 		return m.Option
 	}
 	return nil
 }
 
-func (x *OneOf) GetSemantic() *OneOf_Semantic {
-	if x, ok := x.GetOption().(*OneOf_Semantic_); ok {
-		return x.Semantic
+func (x *SemanticalOneOfMessage) GetSemantical() *SemanticalOneOfMessage_Empty {
+	if x, ok := x.GetOption().(*SemanticalOneOfMessage_Semantical); ok {
+		return x.Semantical
 	}
 	return nil
 }
 
-func (x *OneOf) GetNonSemantic() *OneOf_NonSemantic {
-	if x, ok := x.GetOption().(*OneOf_NonSemantic_); ok {
-		return x.NonSemantic
+func (x *SemanticalOneOfMessage) GetAlternative() *SemanticalOneOfMessage_NonEmpty {
+	if x, ok := x.GetOption().(*SemanticalOneOfMessage_Alternative); ok {
+		return x.Alternative
 	}
 	return nil
 }
 
-type isOneOf_Option interface {
-	isOneOf_Option()
+type isSemanticalOneOfMessage_Option interface {
+	isSemanticalOneOfMessage_Option()
 }
 
-type OneOf_Semantic_ struct {
-	Semantic *OneOf_Semantic `protobuf:"bytes,1,opt,name=semantic,proto3,oneof"`
+type SemanticalOneOfMessage_Semantical struct {
+	Semantical *SemanticalOneOfMessage_Empty `protobuf:"bytes,1,opt,name=semantical,proto3,oneof"`
 }
 
-type OneOf_NonSemantic_ struct {
-	NonSemantic *OneOf_NonSemantic `protobuf:"bytes,2,opt,name=non_semantic,json=nonSemantic,proto3,oneof"`
+type SemanticalOneOfMessage_Alternative struct {
+	Alternative *SemanticalOneOfMessage_NonEmpty `protobuf:"bytes,2,opt,name=alternative,proto3,oneof"`
 }
 
-func (*OneOf_Semantic_) isOneOf_Option() {}
+func (*SemanticalOneOfMessage_Semantical) isSemanticalOneOfMessage_Option() {}
 
-func (*OneOf_NonSemantic_) isOneOf_Option() {}
+func (*SemanticalOneOfMessage_Alternative) isSemanticalOneOfMessage_Option() {}
 
-type NonSemantic_Semantic struct {
+type SemanticalMessage_Empty struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 }
 
-func (x *NonSemantic_Semantic) Reset() {
-	*x = NonSemantic_Semantic{}
+func (x *SemanticalMessage_Empty) Reset() {
+	*x = SemanticalMessage_Empty{}
 	if protoimpl.UnsafeEnabled {
 		mi := &file_message_proto_msgTypes[2]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -176,13 +184,13 @@ func (x *NonSemantic_Semantic) Reset() {
 	}
 }
 
-func (x *NonSemantic_Semantic) String() string {
+func (x *SemanticalMessage_Empty) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*NonSemantic_Semantic) ProtoMessage() {}
+func (*SemanticalMessage_Empty) ProtoMessage() {}
 
-func (x *NonSemantic_Semantic) ProtoReflect() protoreflect.Message {
+func (x *SemanticalMessage_Empty) ProtoReflect() protoreflect.Message {
 	mi := &file_message_proto_msgTypes[2]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -194,19 +202,21 @@ func (x *NonSemantic_Semantic) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use NonSemantic_Semantic.ProtoReflect.Descriptor instead.
-func (*NonSemantic_Semantic) Descriptor() ([]byte, []int) {
+// Deprecated: Use SemanticalMessage_Empty.ProtoReflect.Descriptor instead.
+func (*SemanticalMessage_Empty) Descriptor() ([]byte, []int) {
 	return file_message_proto_rawDescGZIP(), []int{0, 0}
 }
 
-type OneOf_Semantic struct {
+type SemanticalMessage_NonEmpty struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
+
+	BoolValue bool `protobuf:"varint,1,opt,name=bool_value,json=boolValue,proto3" json:"bool_value,omitempty"`
 }
 
-func (x *OneOf_Semantic) Reset() {
-	*x = OneOf_Semantic{}
+func (x *SemanticalMessage_NonEmpty) Reset() {
+	*x = SemanticalMessage_NonEmpty{}
 	if protoimpl.UnsafeEnabled {
 		mi := &file_message_proto_msgTypes[3]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -214,13 +224,13 @@ func (x *OneOf_Semantic) Reset() {
 	}
 }
 
-func (x *OneOf_Semantic) String() string {
+func (x *SemanticalMessage_NonEmpty) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*OneOf_Semantic) ProtoMessage() {}
+func (*SemanticalMessage_NonEmpty) ProtoMessage() {}
 
-func (x *OneOf_Semantic) ProtoReflect() protoreflect.Message {
+func (x *SemanticalMessage_NonEmpty) ProtoReflect() protoreflect.Message {
 	mi := &file_message_proto_msgTypes[3]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -232,21 +242,26 @@ func (x *OneOf_Semantic) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use OneOf_Semantic.ProtoReflect.Descriptor instead.
-func (*OneOf_Semantic) Descriptor() ([]byte, []int) {
-	return file_message_proto_rawDescGZIP(), []int{1, 0}
+// Deprecated: Use SemanticalMessage_NonEmpty.ProtoReflect.Descriptor instead.
+func (*SemanticalMessage_NonEmpty) Descriptor() ([]byte, []int) {
+	return file_message_proto_rawDescGZIP(), []int{0, 1}
 }
 
-type OneOf_NonSemantic struct {
+func (x *SemanticalMessage_NonEmpty) GetBoolValue() bool {
+	if x != nil {
+		return x.BoolValue
+	}
+	return false
+}
+
+type SemanticalOneOfMessage_Empty struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
-
-	Boolean bool `protobuf:"varint,1,opt,name=boolean,proto3" json:"boolean,omitempty"`
 }
 
-func (x *OneOf_NonSemantic) Reset() {
-	*x = OneOf_NonSemantic{}
+func (x *SemanticalOneOfMessage_Empty) Reset() {
+	*x = SemanticalOneOfMessage_Empty{}
 	if protoimpl.UnsafeEnabled {
 		mi := &file_message_proto_msgTypes[4]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -254,13 +269,13 @@ func (x *OneOf_NonSemantic) Reset() {
 	}
 }
 
-func (x *OneOf_NonSemantic) String() string {
+func (x *SemanticalOneOfMessage_Empty) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*OneOf_NonSemantic) ProtoMessage() {}
+func (*SemanticalOneOfMessage_Empty) ProtoMessage() {}
 
-func (x *OneOf_NonSemantic) ProtoReflect() protoreflect.Message {
+func (x *SemanticalOneOfMessage_Empty) ProtoReflect() protoreflect.Message {
 	mi := &file_message_proto_msgTypes[4]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -272,14 +287,54 @@ func (x *OneOf_NonSemantic) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use OneOf_NonSemantic.ProtoReflect.Descriptor instead.
-func (*OneOf_NonSemantic) Descriptor() ([]byte, []int) {
+// Deprecated: Use SemanticalOneOfMessage_Empty.ProtoReflect.Descriptor instead.
+func (*SemanticalOneOfMessage_Empty) Descriptor() ([]byte, []int) {
+	return file_message_proto_rawDescGZIP(), []int{1, 0}
+}
+
+type SemanticalOneOfMessage_NonEmpty struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	BoolValue bool `protobuf:"varint,1,opt,name=bool_value,json=boolValue,proto3" json:"bool_value,omitempty"`
+}
+
+func (x *SemanticalOneOfMessage_NonEmpty) Reset() {
+	*x = SemanticalOneOfMessage_NonEmpty{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_message_proto_msgTypes[5]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *SemanticalOneOfMessage_NonEmpty) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SemanticalOneOfMessage_NonEmpty) ProtoMessage() {}
+
+func (x *SemanticalOneOfMessage_NonEmpty) ProtoReflect() protoreflect.Message {
+	mi := &file_message_proto_msgTypes[5]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SemanticalOneOfMessage_NonEmpty.ProtoReflect.Descriptor instead.
+func (*SemanticalOneOfMessage_NonEmpty) Descriptor() ([]byte, []int) {
 	return file_message_proto_rawDescGZIP(), []int{1, 1}
 }
 
-func (x *OneOf_NonSemantic) GetBoolean() bool {
+func (x *SemanticalOneOfMessage_NonEmpty) GetBoolValue() bool {
 	if x != nil {
-		return x.Boolean
+		return x.BoolValue
 	}
 	return false
 }
@@ -292,39 +347,51 @@ var file_message_proto_rawDesc = []byte{
 	0x2e, 0x74, 0x65, 0x73, 0x74, 0x1a, 0x11, 0x61, 0x6e, 0x6e, 0x6f, 0x74, 0x61, 0x74, 0x69, 0x6f,
 	0x6e, 0x73, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x1a, 0x1d, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x6e,
 	0x61, 0x6c, 0x2f, 0x67, 0x6f, 0x67, 0x6f, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x2f, 0x67, 0x6f, 0x67,
-	0x6f, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x22, 0xda, 0x01, 0x0a, 0x0b, 0x4e, 0x6f, 0x6e, 0x53,
-	0x65, 0x6d, 0x61, 0x6e, 0x74, 0x69, 0x63, 0x12, 0x4e, 0x0a, 0x08, 0x73, 0x65, 0x6d, 0x61, 0x6e,
-	0x74, 0x69, 0x63, 0x18, 0x01, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x2a, 0x2e, 0x74, 0x68, 0x65, 0x74,
-	0x68, 0x69, 0x6e, 0x67, 0x73, 0x2e, 0x66, 0x6c, 0x61, 0x67, 0x73, 0x2e, 0x74, 0x65, 0x73, 0x74,
-	0x2e, 0x4e, 0x6f, 0x6e, 0x53, 0x65, 0x6d, 0x61, 0x6e, 0x74, 0x69, 0x63, 0x2e, 0x53, 0x65, 0x6d,
-	0x61, 0x6e, 0x74, 0x69, 0x63, 0x42, 0x06, 0xf2, 0xaa, 0x19, 0x02, 0x08, 0x00, 0x52, 0x08, 0x73,
-	0x65, 0x6d, 0x61, 0x6e, 0x74, 0x69, 0x63, 0x12, 0x63, 0x0a, 0x12, 0x6f, 0x76, 0x65, 0x72, 0x72,
-	0x75, 0x6c, 0x65, 0x64, 0x5f, 0x73, 0x65, 0x6d, 0x61, 0x6e, 0x74, 0x69, 0x63, 0x18, 0x02, 0x20,
-	0x01, 0x28, 0x0b, 0x32, 0x2a, 0x2e, 0x74, 0x68, 0x65, 0x74, 0x68, 0x69, 0x6e, 0x67, 0x73, 0x2e,
-	0x66, 0x6c, 0x61, 0x67, 0x73, 0x2e, 0x74, 0x65, 0x73, 0x74, 0x2e, 0x4e, 0x6f, 0x6e, 0x53, 0x65,
-	0x6d, 0x61, 0x6e, 0x74, 0x69, 0x63, 0x2e, 0x53, 0x65, 0x6d, 0x61, 0x6e, 0x74, 0x69, 0x63, 0x42,
-	0x08, 0xf2, 0xaa, 0x19, 0x04, 0x08, 0x00, 0x30, 0x00, 0x52, 0x11, 0x6f, 0x76, 0x65, 0x72, 0x72,
-	0x75, 0x6c, 0x65, 0x64, 0x53, 0x65, 0x6d, 0x61, 0x6e, 0x74, 0x69, 0x63, 0x1a, 0x0a, 0x0a, 0x08,
-	0x53, 0x65, 0x6d, 0x61, 0x6e, 0x74, 0x69, 0x63, 0x3a, 0x0a, 0xf2, 0xaa, 0x19, 0x06, 0x08, 0x00,
-	0x10, 0x01, 0x20, 0x01, 0x22, 0xe4, 0x01, 0x0a, 0x05, 0x4f, 0x6e, 0x65, 0x4f, 0x66, 0x12, 0x42,
-	0x0a, 0x08, 0x73, 0x65, 0x6d, 0x61, 0x6e, 0x74, 0x69, 0x63, 0x18, 0x01, 0x20, 0x01, 0x28, 0x0b,
-	0x32, 0x24, 0x2e, 0x74, 0x68, 0x65, 0x74, 0x68, 0x69, 0x6e, 0x67, 0x73, 0x2e, 0x66, 0x6c, 0x61,
-	0x67, 0x73, 0x2e, 0x74, 0x65, 0x73, 0x74, 0x2e, 0x4f, 0x6e, 0x65, 0x4f, 0x66, 0x2e, 0x53, 0x65,
-	0x6d, 0x61, 0x6e, 0x74, 0x69, 0x63, 0x48, 0x00, 0x52, 0x08, 0x73, 0x65, 0x6d, 0x61, 0x6e, 0x74,
-	0x69, 0x63, 0x12, 0x4c, 0x0a, 0x0c, 0x6e, 0x6f, 0x6e, 0x5f, 0x73, 0x65, 0x6d, 0x61, 0x6e, 0x74,
-	0x69, 0x63, 0x18, 0x02, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x27, 0x2e, 0x74, 0x68, 0x65, 0x74, 0x68,
-	0x69, 0x6e, 0x67, 0x73, 0x2e, 0x66, 0x6c, 0x61, 0x67, 0x73, 0x2e, 0x74, 0x65, 0x73, 0x74, 0x2e,
-	0x4f, 0x6e, 0x65, 0x4f, 0x66, 0x2e, 0x4e, 0x6f, 0x6e, 0x53, 0x65, 0x6d, 0x61, 0x6e, 0x74, 0x69,
-	0x63, 0x48, 0x00, 0x52, 0x0b, 0x6e, 0x6f, 0x6e, 0x53, 0x65, 0x6d, 0x61, 0x6e, 0x74, 0x69, 0x63,
-	0x1a, 0x0a, 0x0a, 0x08, 0x53, 0x65, 0x6d, 0x61, 0x6e, 0x74, 0x69, 0x63, 0x1a, 0x27, 0x0a, 0x0b,
-	0x4e, 0x6f, 0x6e, 0x53, 0x65, 0x6d, 0x61, 0x6e, 0x74, 0x69, 0x63, 0x12, 0x18, 0x0a, 0x07, 0x62,
-	0x6f, 0x6f, 0x6c, 0x65, 0x61, 0x6e, 0x18, 0x01, 0x20, 0x01, 0x28, 0x08, 0x52, 0x07, 0x62, 0x6f,
-	0x6f, 0x6c, 0x65, 0x61, 0x6e, 0x3a, 0x0a, 0xf2, 0xaa, 0x19, 0x06, 0x08, 0x00, 0x10, 0x01, 0x20,
-	0x01, 0x42, 0x08, 0x0a, 0x06, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x42, 0x39, 0x5a, 0x37, 0x67,
-	0x69, 0x74, 0x68, 0x75, 0x62, 0x2e, 0x63, 0x6f, 0x6d, 0x2f, 0x54, 0x68, 0x65, 0x54, 0x68, 0x69,
-	0x6e, 0x67, 0x73, 0x49, 0x6e, 0x64, 0x75, 0x73, 0x74, 0x72, 0x69, 0x65, 0x73, 0x2f, 0x70, 0x72,
-	0x6f, 0x74, 0x6f, 0x63, 0x2d, 0x67, 0x65, 0x6e, 0x2d, 0x67, 0x6f, 0x2d, 0x66, 0x6c, 0x61, 0x67,
-	0x73, 0x2f, 0x74, 0x65, 0x73, 0x74, 0x62, 0x06, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33,
+	0x6f, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x22, 0xdb, 0x02, 0x0a, 0x11, 0x53, 0x65, 0x6d, 0x61,
+	0x6e, 0x74, 0x69, 0x63, 0x61, 0x6c, 0x4d, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65, 0x12, 0x43, 0x0a,
+	0x05, 0x65, 0x6d, 0x70, 0x74, 0x79, 0x18, 0x01, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x2d, 0x2e, 0x74,
+	0x68, 0x65, 0x74, 0x68, 0x69, 0x6e, 0x67, 0x73, 0x2e, 0x66, 0x6c, 0x61, 0x67, 0x73, 0x2e, 0x74,
+	0x65, 0x73, 0x74, 0x2e, 0x53, 0x65, 0x6d, 0x61, 0x6e, 0x74, 0x69, 0x63, 0x61, 0x6c, 0x4d, 0x65,
+	0x73, 0x73, 0x61, 0x67, 0x65, 0x2e, 0x45, 0x6d, 0x70, 0x74, 0x79, 0x52, 0x05, 0x65, 0x6d, 0x70,
+	0x74, 0x79, 0x12, 0x5e, 0x0a, 0x0f, 0x65, 0x6d, 0x70, 0x74, 0x79, 0x5f, 0x6f, 0x76, 0x65, 0x72,
+	0x72, 0x75, 0x6c, 0x65, 0x64, 0x18, 0x02, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x2d, 0x2e, 0x74, 0x68,
+	0x65, 0x74, 0x68, 0x69, 0x6e, 0x67, 0x73, 0x2e, 0x66, 0x6c, 0x61, 0x67, 0x73, 0x2e, 0x74, 0x65,
+	0x73, 0x74, 0x2e, 0x53, 0x65, 0x6d, 0x61, 0x6e, 0x74, 0x69, 0x63, 0x61, 0x6c, 0x4d, 0x65, 0x73,
+	0x73, 0x61, 0x67, 0x65, 0x2e, 0x45, 0x6d, 0x70, 0x74, 0x79, 0x42, 0x06, 0xf2, 0xaa, 0x19, 0x02,
+	0x30, 0x00, 0x52, 0x0e, 0x65, 0x6d, 0x70, 0x74, 0x79, 0x4f, 0x76, 0x65, 0x72, 0x72, 0x75, 0x6c,
+	0x65, 0x64, 0x12, 0x4d, 0x0a, 0x09, 0x6e, 0x6f, 0x6e, 0x5f, 0x65, 0x6d, 0x70, 0x74, 0x79, 0x18,
+	0x03, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x30, 0x2e, 0x74, 0x68, 0x65, 0x74, 0x68, 0x69, 0x6e, 0x67,
+	0x73, 0x2e, 0x66, 0x6c, 0x61, 0x67, 0x73, 0x2e, 0x74, 0x65, 0x73, 0x74, 0x2e, 0x53, 0x65, 0x6d,
+	0x61, 0x6e, 0x74, 0x69, 0x63, 0x61, 0x6c, 0x4d, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65, 0x2e, 0x4e,
+	0x6f, 0x6e, 0x45, 0x6d, 0x70, 0x74, 0x79, 0x52, 0x08, 0x6e, 0x6f, 0x6e, 0x45, 0x6d, 0x70, 0x74,
+	0x79, 0x1a, 0x11, 0x0a, 0x05, 0x45, 0x6d, 0x70, 0x74, 0x79, 0x3a, 0x08, 0xf2, 0xaa, 0x19, 0x04,
+	0x08, 0x00, 0x10, 0x01, 0x1a, 0x33, 0x0a, 0x08, 0x4e, 0x6f, 0x6e, 0x45, 0x6d, 0x70, 0x74, 0x79,
+	0x12, 0x1d, 0x0a, 0x0a, 0x62, 0x6f, 0x6f, 0x6c, 0x5f, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x18, 0x01,
+	0x20, 0x01, 0x28, 0x08, 0x52, 0x09, 0x62, 0x6f, 0x6f, 0x6c, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x3a,
+	0x08, 0xf2, 0xaa, 0x19, 0x04, 0x08, 0x00, 0x10, 0x01, 0x3a, 0x0a, 0xf2, 0xaa, 0x19, 0x06, 0x08,
+	0x00, 0x10, 0x01, 0x20, 0x01, 0x22, 0x9d, 0x02, 0x0a, 0x16, 0x53, 0x65, 0x6d, 0x61, 0x6e, 0x74,
+	0x69, 0x63, 0x61, 0x6c, 0x4f, 0x6e, 0x65, 0x4f, 0x66, 0x4d, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65,
+	0x12, 0x54, 0x0a, 0x0a, 0x73, 0x65, 0x6d, 0x61, 0x6e, 0x74, 0x69, 0x63, 0x61, 0x6c, 0x18, 0x01,
+	0x20, 0x01, 0x28, 0x0b, 0x32, 0x32, 0x2e, 0x74, 0x68, 0x65, 0x74, 0x68, 0x69, 0x6e, 0x67, 0x73,
+	0x2e, 0x66, 0x6c, 0x61, 0x67, 0x73, 0x2e, 0x74, 0x65, 0x73, 0x74, 0x2e, 0x53, 0x65, 0x6d, 0x61,
+	0x6e, 0x74, 0x69, 0x63, 0x61, 0x6c, 0x4f, 0x6e, 0x65, 0x4f, 0x66, 0x4d, 0x65, 0x73, 0x73, 0x61,
+	0x67, 0x65, 0x2e, 0x45, 0x6d, 0x70, 0x74, 0x79, 0x48, 0x00, 0x52, 0x0a, 0x73, 0x65, 0x6d, 0x61,
+	0x6e, 0x74, 0x69, 0x63, 0x61, 0x6c, 0x12, 0x59, 0x0a, 0x0b, 0x61, 0x6c, 0x74, 0x65, 0x72, 0x6e,
+	0x61, 0x74, 0x69, 0x76, 0x65, 0x18, 0x02, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x35, 0x2e, 0x74, 0x68,
+	0x65, 0x74, 0x68, 0x69, 0x6e, 0x67, 0x73, 0x2e, 0x66, 0x6c, 0x61, 0x67, 0x73, 0x2e, 0x74, 0x65,
+	0x73, 0x74, 0x2e, 0x53, 0x65, 0x6d, 0x61, 0x6e, 0x74, 0x69, 0x63, 0x61, 0x6c, 0x4f, 0x6e, 0x65,
+	0x4f, 0x66, 0x4d, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65, 0x2e, 0x4e, 0x6f, 0x6e, 0x45, 0x6d, 0x70,
+	0x74, 0x79, 0x48, 0x00, 0x52, 0x0b, 0x61, 0x6c, 0x74, 0x65, 0x72, 0x6e, 0x61, 0x74, 0x69, 0x76,
+	0x65, 0x1a, 0x07, 0x0a, 0x05, 0x45, 0x6d, 0x70, 0x74, 0x79, 0x1a, 0x33, 0x0a, 0x08, 0x4e, 0x6f,
+	0x6e, 0x45, 0x6d, 0x70, 0x74, 0x79, 0x12, 0x1d, 0x0a, 0x0a, 0x62, 0x6f, 0x6f, 0x6c, 0x5f, 0x76,
+	0x61, 0x6c, 0x75, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x08, 0x52, 0x09, 0x62, 0x6f, 0x6f, 0x6c,
+	0x56, 0x61, 0x6c, 0x75, 0x65, 0x3a, 0x08, 0xf2, 0xaa, 0x19, 0x04, 0x08, 0x00, 0x10, 0x01, 0x3a,
+	0x0a, 0xf2, 0xaa, 0x19, 0x06, 0x08, 0x00, 0x10, 0x01, 0x20, 0x01, 0x42, 0x08, 0x0a, 0x06, 0x6f,
+	0x70, 0x74, 0x69, 0x6f, 0x6e, 0x42, 0x39, 0x5a, 0x37, 0x67, 0x69, 0x74, 0x68, 0x75, 0x62, 0x2e,
+	0x63, 0x6f, 0x6d, 0x2f, 0x54, 0x68, 0x65, 0x54, 0x68, 0x69, 0x6e, 0x67, 0x73, 0x49, 0x6e, 0x64,
+	0x75, 0x73, 0x74, 0x72, 0x69, 0x65, 0x73, 0x2f, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x63, 0x2d, 0x67,
+	0x65, 0x6e, 0x2d, 0x67, 0x6f, 0x2d, 0x66, 0x6c, 0x61, 0x67, 0x73, 0x2f, 0x74, 0x65, 0x73, 0x74,
+	0x62, 0x06, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33,
 }
 
 var (
@@ -339,24 +406,26 @@ func file_message_proto_rawDescGZIP() []byte {
 	return file_message_proto_rawDescData
 }
 
-var file_message_proto_msgTypes = make([]protoimpl.MessageInfo, 5)
+var file_message_proto_msgTypes = make([]protoimpl.MessageInfo, 6)
 var file_message_proto_goTypes = []interface{}{
-	(*NonSemantic)(nil),          // 0: thethings.flags.test.NonSemantic
-	(*OneOf)(nil),                // 1: thethings.flags.test.OneOf
-	(*NonSemantic_Semantic)(nil), // 2: thethings.flags.test.NonSemantic.Semantic
-	(*OneOf_Semantic)(nil),       // 3: thethings.flags.test.OneOf.Semantic
-	(*OneOf_NonSemantic)(nil),    // 4: thethings.flags.test.OneOf.NonSemantic
+	(*SemanticalMessage)(nil),               // 0: thethings.flags.test.SemanticalMessage
+	(*SemanticalOneOfMessage)(nil),          // 1: thethings.flags.test.SemanticalOneOfMessage
+	(*SemanticalMessage_Empty)(nil),         // 2: thethings.flags.test.SemanticalMessage.Empty
+	(*SemanticalMessage_NonEmpty)(nil),      // 3: thethings.flags.test.SemanticalMessage.NonEmpty
+	(*SemanticalOneOfMessage_Empty)(nil),    // 4: thethings.flags.test.SemanticalOneOfMessage.Empty
+	(*SemanticalOneOfMessage_NonEmpty)(nil), // 5: thethings.flags.test.SemanticalOneOfMessage.NonEmpty
 }
 var file_message_proto_depIdxs = []int32{
-	2, // 0: thethings.flags.test.NonSemantic.semantic:type_name -> thethings.flags.test.NonSemantic.Semantic
-	2, // 1: thethings.flags.test.NonSemantic.overruled_semantic:type_name -> thethings.flags.test.NonSemantic.Semantic
-	3, // 2: thethings.flags.test.OneOf.semantic:type_name -> thethings.flags.test.OneOf.Semantic
-	4, // 3: thethings.flags.test.OneOf.non_semantic:type_name -> thethings.flags.test.OneOf.NonSemantic
-	4, // [4:4] is the sub-list for method output_type
-	4, // [4:4] is the sub-list for method input_type
-	4, // [4:4] is the sub-list for extension type_name
-	4, // [4:4] is the sub-list for extension extendee
-	0, // [0:4] is the sub-list for field type_name
+	2, // 0: thethings.flags.test.SemanticalMessage.empty:type_name -> thethings.flags.test.SemanticalMessage.Empty
+	2, // 1: thethings.flags.test.SemanticalMessage.empty_overruled:type_name -> thethings.flags.test.SemanticalMessage.Empty
+	3, // 2: thethings.flags.test.SemanticalMessage.non_empty:type_name -> thethings.flags.test.SemanticalMessage.NonEmpty
+	4, // 3: thethings.flags.test.SemanticalOneOfMessage.semantical:type_name -> thethings.flags.test.SemanticalOneOfMessage.Empty
+	5, // 4: thethings.flags.test.SemanticalOneOfMessage.alternative:type_name -> thethings.flags.test.SemanticalOneOfMessage.NonEmpty
+	5, // [5:5] is the sub-list for method output_type
+	5, // [5:5] is the sub-list for method input_type
+	5, // [5:5] is the sub-list for extension type_name
+	5, // [5:5] is the sub-list for extension extendee
+	0, // [0:5] is the sub-list for field type_name
 }
 
 func init() { file_message_proto_init() }
@@ -366,7 +435,7 @@ func file_message_proto_init() {
 	}
 	if !protoimpl.UnsafeEnabled {
 		file_message_proto_msgTypes[0].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*NonSemantic); i {
+			switch v := v.(*SemanticalMessage); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -378,7 +447,7 @@ func file_message_proto_init() {
 			}
 		}
 		file_message_proto_msgTypes[1].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*OneOf); i {
+			switch v := v.(*SemanticalOneOfMessage); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -390,7 +459,7 @@ func file_message_proto_init() {
 			}
 		}
 		file_message_proto_msgTypes[2].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*NonSemantic_Semantic); i {
+			switch v := v.(*SemanticalMessage_Empty); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -402,7 +471,7 @@ func file_message_proto_init() {
 			}
 		}
 		file_message_proto_msgTypes[3].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*OneOf_Semantic); i {
+			switch v := v.(*SemanticalMessage_NonEmpty); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -414,7 +483,19 @@ func file_message_proto_init() {
 			}
 		}
 		file_message_proto_msgTypes[4].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*OneOf_NonSemantic); i {
+			switch v := v.(*SemanticalOneOfMessage_Empty); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_message_proto_msgTypes[5].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*SemanticalOneOfMessage_NonEmpty); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -427,8 +508,8 @@ func file_message_proto_init() {
 		}
 	}
 	file_message_proto_msgTypes[1].OneofWrappers = []interface{}{
-		(*OneOf_Semantic_)(nil),
-		(*OneOf_NonSemantic_)(nil),
+		(*SemanticalOneOfMessage_Semantical)(nil),
+		(*SemanticalOneOfMessage_Alternative)(nil),
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
@@ -436,7 +517,7 @@ func file_message_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: file_message_proto_rawDesc,
 			NumEnums:      0,
-			NumMessages:   5,
+			NumMessages:   6,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/test/golang/message_flags.pb.go
+++ b/test/golang/message_flags.pb.go
@@ -11,44 +11,126 @@ import (
 	pflag "github.com/spf13/pflag"
 )
 
-// AddSetFlagsForNonSemantic adds flags to select fields in NonSemantic.
-func AddSetFlagsForNonSemantic(flags *pflag.FlagSet, prefix string, hidden bool) {
-	flags.AddFlag(flagsplugin.NewBoolFlag(flagsplugin.Prefix("semantic", prefix), "", flagsplugin.WithHidden(hidden)))
-	// FIXME: Skipping OverruledSemantic because it does not seem to implement AddSetFlags.
+// AddSetFlagsForSemanticalMessage_Empty adds flags to select fields in SemanticalMessage_Empty.
+func AddSetFlagsForSemanticalMessage_Empty(flags *pflag.FlagSet, prefix string, hidden bool) {
 }
 
-// SetFromFlags sets the NonSemantic message from flags.
-func (m *NonSemantic) SetFromFlags(flags *pflag.FlagSet, prefix string) (paths []string, err error) {
-	if _, changed, err := flagsplugin.GetBool(flags, flagsplugin.Prefix("semantic", prefix)); err != nil {
-		return nil, err
-	} else if changed {
-		m.Semantic = &NonSemantic_Semantic{}
-		paths = append(paths, flagsplugin.Prefix("semantic", prefix))
-	}
-	// FIXME: Skipping OverruledSemantic because it does not seem to implement AddSetFlags.
+// SetFromFlags sets the SemanticalMessage_Empty message from flags.
+func (m *SemanticalMessage_Empty) SetFromFlags(flags *pflag.FlagSet, prefix string) (paths []string, err error) {
 	return paths, nil
 }
 
-// AddSetFlagsForOneOf adds flags to select fields in OneOf.
-func AddSetFlagsForOneOf(flags *pflag.FlagSet, prefix string, hidden bool) {
-	flags.AddFlag(flagsplugin.NewBoolFlag(flagsplugin.Prefix("option.semantic", prefix), "", flagsplugin.WithHidden(hidden)))
-	flags.AddFlag(flagsplugin.NewBoolFlag(flagsplugin.Prefix("option.non-semantic", prefix), "", flagsplugin.WithHidden(hidden)))
+// AddSetFlagsForSemanticalMessage_NonEmpty adds flags to select fields in SemanticalMessage_NonEmpty.
+func AddSetFlagsForSemanticalMessage_NonEmpty(flags *pflag.FlagSet, prefix string, hidden bool) {
+	flags.AddFlag(flagsplugin.NewBoolFlag(flagsplugin.Prefix("bool-value", prefix), "", flagsplugin.WithHidden(hidden)))
 }
 
-// SetFromFlags sets the OneOf message from flags.
-func (m *OneOf) SetFromFlags(flags *pflag.FlagSet, prefix string) (paths []string, err error) {
-	if _, changed, err := flagsplugin.GetBool(flags, flagsplugin.Prefix("option.semantic", prefix)); err != nil {
+// SetFromFlags sets the SemanticalMessage_NonEmpty message from flags.
+func (m *SemanticalMessage_NonEmpty) SetFromFlags(flags *pflag.FlagSet, prefix string) (paths []string, err error) {
+	if val, changed, err := flagsplugin.GetBool(flags, flagsplugin.Prefix("bool_value", prefix)); err != nil {
 		return nil, err
 	} else if changed {
-		ov := &OneOf_Semantic_{}
-		paths = append(paths, flagsplugin.Prefix("option.semantic", prefix))
+		m.BoolValue = val
+		paths = append(paths, flagsplugin.Prefix("bool_value", prefix))
+	}
+	return paths, nil
+}
+
+// AddSetFlagsForSemanticalMessage adds flags to select fields in SemanticalMessage.
+func AddSetFlagsForSemanticalMessage(flags *pflag.FlagSet, prefix string, hidden bool) {
+	AddSetFlagsForSemanticalMessage_Empty(flags, flagsplugin.Prefix("empty", prefix), hidden)
+	flags.AddFlag(flagsplugin.NewBoolFlag(flagsplugin.Prefix("empty", prefix), "", flagsplugin.WithHidden(hidden)))
+	AddSetFlagsForSemanticalMessage_Empty(flags, flagsplugin.Prefix("empty-overruled", prefix), hidden)
+	AddSetFlagsForSemanticalMessage_NonEmpty(flags, flagsplugin.Prefix("non-empty", prefix), hidden)
+	flags.AddFlag(flagsplugin.NewBoolFlag(flagsplugin.Prefix("non-empty", prefix), "", flagsplugin.WithHidden(hidden)))
+}
+
+// SetFromFlags sets the SemanticalMessage message from flags.
+func (m *SemanticalMessage) SetFromFlags(flags *pflag.FlagSet, prefix string) (paths []string, err error) {
+	if changed := flagsplugin.IsAnyPrefixSet(flags, flagsplugin.Prefix("empty", prefix)); changed {
+		if m.Empty == nil {
+			m.Empty = &SemanticalMessage_Empty{}
+		}
+		if setPaths, err := m.Empty.SetFromFlags(flags, flagsplugin.Prefix("empty", prefix)); err != nil {
+			return nil, err
+		} else if len(setPaths) == 0 {
+			paths = append(paths, "empty")
+		} else {
+			paths = append(paths, setPaths...)
+		}
+	}
+	if changed := flagsplugin.IsAnyPrefixSet(flags, flagsplugin.Prefix("empty_overruled", prefix)); changed {
+		if m.EmptyOverruled == nil {
+			m.EmptyOverruled = &SemanticalMessage_Empty{}
+		}
+		if setPaths, err := m.EmptyOverruled.SetFromFlags(flags, flagsplugin.Prefix("empty_overruled", prefix)); err != nil {
+			return nil, err
+		} else {
+			paths = append(paths, setPaths...)
+		}
+	}
+	if changed := flagsplugin.IsAnyPrefixSet(flags, flagsplugin.Prefix("non_empty", prefix)); changed {
+		if m.NonEmpty == nil {
+			m.NonEmpty = &SemanticalMessage_NonEmpty{}
+		}
+		if setPaths, err := m.NonEmpty.SetFromFlags(flags, flagsplugin.Prefix("non_empty", prefix)); err != nil {
+			return nil, err
+		} else if len(setPaths) == 0 {
+			paths = append(paths, "non_empty")
+		} else {
+			paths = append(paths, setPaths...)
+		}
+	}
+	return paths, nil
+}
+
+// AddSetFlagsForSemanticalOneOfMessage_NonEmpty adds flags to select fields in SemanticalOneOfMessage_NonEmpty.
+func AddSetFlagsForSemanticalOneOfMessage_NonEmpty(flags *pflag.FlagSet, prefix string, hidden bool) {
+	flags.AddFlag(flagsplugin.NewBoolFlag(flagsplugin.Prefix("bool-value", prefix), "", flagsplugin.WithHidden(hidden)))
+}
+
+// SetFromFlags sets the SemanticalOneOfMessage_NonEmpty message from flags.
+func (m *SemanticalOneOfMessage_NonEmpty) SetFromFlags(flags *pflag.FlagSet, prefix string) (paths []string, err error) {
+	if val, changed, err := flagsplugin.GetBool(flags, flagsplugin.Prefix("bool_value", prefix)); err != nil {
+		return nil, err
+	} else if changed {
+		m.BoolValue = val
+		paths = append(paths, flagsplugin.Prefix("bool_value", prefix))
+	}
+	return paths, nil
+}
+
+// AddSetFlagsForSemanticalOneOfMessage adds flags to select fields in SemanticalOneOfMessage.
+func AddSetFlagsForSemanticalOneOfMessage(flags *pflag.FlagSet, prefix string, hidden bool) {
+	flags.AddFlag(flagsplugin.NewBoolFlag(flagsplugin.Prefix("option.semantical", prefix), "", flagsplugin.WithHidden(hidden)))
+	AddSetFlagsForSemanticalOneOfMessage_NonEmpty(flags, flagsplugin.Prefix("option.alternative", prefix), hidden)
+	flags.AddFlag(flagsplugin.NewBoolFlag(flagsplugin.Prefix("option.alternative", prefix), "", flagsplugin.WithHidden(hidden)))
+}
+
+// SetFromFlags sets the SemanticalOneOfMessage message from flags.
+func (m *SemanticalOneOfMessage) SetFromFlags(flags *pflag.FlagSet, prefix string) (paths []string, err error) {
+	if _, changed, err := flagsplugin.GetBool(flags, flagsplugin.Prefix("option.semantical", prefix)); err != nil {
+		return nil, err
+	} else if changed {
+		ov := &SemanticalOneOfMessage_Semantical{}
+		if ov.Semantical == nil {
+			ov.Semantical = &SemanticalOneOfMessage_Empty{}
+		}
+		paths = append(paths, flagsplugin.Prefix("option.semantical", prefix))
 		m.Option = ov
 	}
-	if _, changed, err := flagsplugin.GetBool(flags, flagsplugin.Prefix("option.non_semantic", prefix)); err != nil {
-		return nil, err
-	} else if changed {
-		ov := &OneOf_NonSemantic_{}
-		paths = append(paths, flagsplugin.Prefix("option.non_semantic", prefix))
+	if changed := flagsplugin.IsAnyPrefixSet(flags, flagsplugin.Prefix("option.alternative", prefix)); changed {
+		ov := &SemanticalOneOfMessage_Alternative{}
+		if ov.Alternative == nil {
+			ov.Alternative = &SemanticalOneOfMessage_NonEmpty{}
+		}
+		if setPaths, err := ov.Alternative.SetFromFlags(flags, flagsplugin.Prefix("option.alternative", prefix)); err != nil {
+			return nil, err
+		} else if len(setPaths) == 0 {
+			paths = append(paths, "option.alternative")
+		} else {
+			paths = append(paths, setPaths...)
+		}
 		m.Option = ov
 	}
 	return paths, nil

--- a/test/golang/message_test.go
+++ b/test/golang/message_test.go
@@ -10,56 +10,92 @@ import (
 var testMessagesWithSemanticalMeaning = []struct {
 	name            string
 	arguments       []string
-	expectedMessage NonSemantic
+	expectedMessage SemanticalMessage
 	expectedMask    []string
 }{
 	{
 		name:      "exists",
-		arguments: []string{"--semantic"},
-		expectedMessage: NonSemantic{
-			Semantic: &NonSemantic_Semantic{},
+		arguments: []string{"--empty"},
+		expectedMessage: SemanticalMessage{
+			Empty: &SemanticalMessage_Empty{},
 		},
-		expectedMask: []string{"semantic"},
+		expectedMask: []string{"empty"},
 	},
 	{
 		name:      "doesn't exist",
 		arguments: []string{},
-		expectedMessage: NonSemantic{
-			Semantic: nil,
+		expectedMessage: SemanticalMessage{
+			Empty:          nil,
+			EmptyOverruled: nil,
+			NonEmpty:       nil,
 		},
 		expectedMask: nil,
+	},
+	{
+		name:      "non_empty semantical",
+		arguments: []string{"--non-empty"},
+		expectedMessage: SemanticalMessage{
+			NonEmpty: &SemanticalMessage_NonEmpty{},
+		},
+		expectedMask: []string{"non_empty"},
+	},
+	{
+		name:      "non_empty with value",
+		arguments: []string{"--non-empty.bool-value", "true"},
+		expectedMessage: SemanticalMessage{
+			NonEmpty: &SemanticalMessage_NonEmpty{
+				BoolValue: true,
+			},
+		},
+		expectedMask: []string{"non_empty.bool_value"},
 	},
 }
 
 var testMessagesWithOneOfSemanticalMeaning = []struct {
 	name            string
 	arguments       []string
-	expectedMessage OneOf
+	expectedMessage SemanticalOneOfMessage
 	expectedMask    []string
 }{
 	{
-		name:      "semantic exists",
-		arguments: []string{"--option.semantic"},
-		expectedMessage: OneOf{
-			Option: &OneOf_Semantic_{},
+		name:      "alternative exists",
+		arguments: []string{"--option.alternative"},
+		expectedMessage: SemanticalOneOfMessage{
+			Option: &SemanticalOneOfMessage_Alternative{
+				Alternative: &SemanticalOneOfMessage_NonEmpty{},
+			},
 		},
-		expectedMask: []string{"option.semantic"},
+		expectedMask: []string{"option.alternative"},
 	},
 	{
 		name:      "doesn't exist",
 		arguments: []string{},
-		expectedMessage: OneOf{
+		expectedMessage: SemanticalOneOfMessage{
 			Option: nil,
 		},
 		expectedMask: nil,
 	},
 	{
-		name:      "nonsemantic exists",
-		arguments: []string{"--option.non-semantic"},
-		expectedMessage: OneOf{
-			Option: &OneOf_NonSemantic_{},
+		name:      "semantical exists",
+		arguments: []string{"--option.semantical"},
+		expectedMessage: SemanticalOneOfMessage{
+			Option: &SemanticalOneOfMessage_Semantical{
+				Semantical: &SemanticalOneOfMessage_Empty{},
+			},
 		},
-		expectedMask: []string{"option.non_semantic"},
+		expectedMask: []string{"option.semantical"},
+	},
+	{
+		name:      "alternative exists with value",
+		arguments: []string{"--option.alternative.bool-value", "true"},
+		expectedMessage: SemanticalOneOfMessage{
+			Option: &SemanticalOneOfMessage_Alternative{
+				Alternative: &SemanticalOneOfMessage_NonEmpty{
+					BoolValue: true,
+				},
+			},
+		},
+		expectedMask: []string{"option.alternative.bool_value"},
 	},
 }
 
@@ -67,7 +103,7 @@ func TestSetFlagsMessageWithSemanticalMeaning(t *testing.T) {
 	for _, tt := range testMessagesWithSemanticalMeaning {
 		t.Run(tt.name, func(t *testing.T) {
 			fs := &pflag.FlagSet{}
-			AddSetFlagsForNonSemantic(fs, "", false)
+			AddSetFlagsForSemanticalMessage(fs, "", false)
 			expectMessageEqual(t, fs, tt.arguments, &tt.expectedMessage, tt.expectedMask)
 		})
 	}
@@ -77,7 +113,7 @@ func TestSetFlagsMessageWithOneOfSemanticalMeaning(t *testing.T) {
 	for _, tt := range testMessagesWithOneOfSemanticalMeaning {
 		t.Run(tt.name, func(t *testing.T) {
 			fs := &pflag.FlagSet{}
-			AddSetFlagsForOneOf(fs, "", false)
+			AddSetFlagsForSemanticalOneOfMessage(fs, "", false)
 			expectMessageEqual(t, fs, tt.arguments, &tt.expectedMessage, tt.expectedMask)
 		})
 	}

--- a/test/message.proto
+++ b/test/message.proto
@@ -10,33 +10,41 @@ package thethings.flags.test;
 
 option go_package = "github.com/TheThingsIndustries/protoc-gen-go-flags/test";
 
-message NonSemantic {
+message SemanticalMessage {
   option (thethings.flags.message) = { select: false, set: true, semantical: true };
 
-  message Semantic {
+  message Empty {
+    option (thethings.flags.message) = { select: false, set: true};
   }
 
-  Semantic semantic = 1 [
-    (thethings.flags.field) = { select: false } 
+  message NonEmpty {
+    option (thethings.flags.message) = { select: false, set: true};
+    
+    bool bool_value = 1;
+  }
+
+  Empty empty = 1;
+
+  Empty empty_overruled = 2 [
+    (thethings.flags.field) = { semantical: false }
   ];
 
-  Semantic overruled_semantic = 2 [
-    (thethings.flags.field) = { select: false, semantical: false }
-  ];
+  NonEmpty non_empty = 3;
 }
 
-message OneOf {
+message SemanticalOneOfMessage {
   option (thethings.flags.message) = { select: false, set: true, semantical: true };
-  message Semantic {
+  message Empty {
   }
 
-  message NonSemantic {
-    bool boolean = 1;
+  message NonEmpty {
+    option (thethings.flags.message) = { select: false, set: true };
+    bool bool_value = 1;
   }
 
   oneof option {
-    Semantic semantic = 1;
-    NonSemantic non_semantic = 2;
+    Empty semantical = 1;
+    NonEmpty alternative = 2;
   }
 }
 


### PR DESCRIPTION
This PR is in addition to #16 and #17 and related to issue #14.

It adds `semantical` support for messages with `set` tags.